### PR TITLE
Implement simple chat app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ m4/lt~obsolete.m4
 # can automatically generate from config.status script
 # (which is called by configure script))
 Makefile
+
+# Node dependencies
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ImChat
+
+This is a minimal chat application using Node.js, Express, and Socket.IO.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the server:
+
+```bash
+npm start
+```
+
+3. Open your browser at `http://localhost:3000` to use the chat.
+
+The admin endpoint is available at `http://localhost:3000/admin/messages` and returns the chat history in JSON format.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "imchat",
+  "version": "1.0.0",
+  "description": "Simple chat application",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.5.4"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ImChat</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    #messages { list-style: none; padding: 0; }
+    #messages li { margin: 5px 0; }
+  </style>
+</head>
+<body>
+  <h1>ImChat</h1>
+  <ul id="messages"></ul>
+  <form id="form" autocomplete="off">
+    <input id="input" /><button>Send</button>
+  </form>
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const socket = io();
+    const form = document.getElementById('form');
+    const input = document.getElementById('input');
+    const messages = document.getElementById('messages');
+
+    function addMessage(message) {
+      const item = document.createElement('li');
+      const date = new Date(message.time);
+      item.textContent = `[${date.toLocaleTimeString()}] ${message.text}`;
+      messages.appendChild(item);
+      window.scrollTo(0, document.body.scrollHeight);
+    }
+
+    socket.on('chat history', (history) => {
+      messages.innerHTML = '';
+      history.forEach(addMessage);
+    });
+
+    socket.on('chat message', addMessage);
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      if (input.value) {
+        socket.emit('chat message', input.value);
+        input.value = '';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+const PORT = process.env.PORT || 3000;
+
+const messages = [];
+
+app.use(express.static('public'));
+
+app.get('/admin/messages', (req, res) => {
+  res.json(messages);
+});
+
+io.on('connection', (socket) => {
+  socket.emit('chat history', messages);
+  socket.on('chat message', (msg) => {
+    const message = { text: msg, time: Date.now() };
+    messages.push(message);
+    io.emit('chat message', message);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js/Socket.IO chat backend
- serve a simple frontend from `public`
- document setup in README
- ignore `node_modules`

## Testing
- `node -v`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841fd324814832cb0d8089f0b348947